### PR TITLE
Update package overrides for security and compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,9 +1241,9 @@
       }
     },
     "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
-      "integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
+      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4767,9 +4767,9 @@
       "license": "MIT"
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "license": "MIT"
     },
     "node_modules/lodash.once": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2244,13 +2244,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
-      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
+      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "vite-imagetools": "^9.0.2"
   },
   "overrides": {
+    "@isaacs/brace-expansion": "^5.0.1",
     "axios": "^1.13.5",
     "cookie": "^0.7.0",
+    "lodash": "^4.17.23",
     "tar": "^7.5.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "vite-imagetools": "^9.0.2"
   },
   "overrides": {
+    "axios": "^1.13.5",
     "cookie": "^0.7.0",
     "tar": "^7.5.7"
   }


### PR DESCRIPTION
## Summary
Updated the `overrides` section in package.json to enforce specific versions of critical dependencies, improving security and ensuring compatibility across the project.

## Changes
- Added `@isaacs/brace-expansion` override to version `^5.0.1`
- Added `axios` override to version `^1.13.5`
- Added `lodash` override to version `^4.17.23`
- Maintained existing overrides for `cookie` (`^0.7.0`) and `tar` (`^7.5.7`)

## Details
These overrides ensure that transitive dependencies resolve to secure and stable versions, preventing version conflicts and potential vulnerabilities in the dependency tree. This is particularly important for widely-used packages like axios and lodash that may be pulled in by multiple dependencies with varying version requirements.

https://claude.ai/code/session_01E6wwPyasj27ZPC4V4QtRCt