### PR TITLE
Pin Vite dependency to version 7.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6784,9 +6784,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "dev": true,
       "license": "MIT",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "vite-imagetools": "^9.0.2"
   },
   "overrides": {
+    "vite": "^7.3.2",
     "minimatch": "^10.2.4",
     "@isaacs/brace-expansion": "^5.0.1",
     "axios": "^1.13.5",


### PR DESCRIPTION
## Summary
This change adds an explicit version override for the Vite dependency to ensure consistent builds across the project.

## Changes
- Added `"vite": "^7.3.2"` to the `overrides` section in package.json to pin Vite to version 7.3.2 or compatible patch versions

## Details
This override ensures that Vite is resolved to version 7.3.2 or higher within the 7.3.x range, preventing unexpected major or minor version upgrades that could introduce breaking changes. This is particularly useful in monorepo or complex dependency scenarios where transitive dependencies might otherwise resolve to different Vite versions.

https://claude.ai/code/session_014sJsmiT9aEzGiQr1SMiS3x