### PR TITLE
Upgrade axios dependency from 1.13.5 to 1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2221,14 +2221,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -5596,10 +5596,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pump": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vite": "^7.3.2",
     "minimatch": "^10.2.4",
     "@isaacs/brace-expansion": "^5.0.1",
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "cookie": "^0.7.0",
     "lodash": "^4.18.0",
     "rollup": "^4.59.0",


### PR DESCRIPTION
## Summary
This pull request updates the axios HTTP client library to a newer version to benefit from bug fixes, performance improvements, and security patches.

## Changes
- Updated axios from `^1.13.5` to `^1.15.0` in package.json

## Details
This is a minor version bump within the same major version (1.x), which maintains backward compatibility while incorporating improvements from the intermediate releases. The lockfile has been updated to reflect the new dependency resolution.

https://claude.ai/code/session_01UNvfRQoTBbFdrqVp882BMb